### PR TITLE
Add Helpshift to the list of Clojure companies

### DIFF
--- a/source/2022-02-11-long-term-clojure-benefits.html.md
+++ b/source/2022-02-11-long-term-clojure-benefits.html.md
@@ -74,3 +74,4 @@ Are you ready to invest in Clojure? Then these companies are ready to invest in 
 -   Reify Health
 -   Metabase
 -   Logseq
+-   Helpshift


### PR DESCRIPTION
Helpshift uses Clojure extensively on the backend, and has been hiring and training world class Clojure engineers since 2010. Helpshift Alumni are members of a lot of Clojure companies as well as FAANG companies throughout the world.

We have worked hard on our Onboarding program and take great joy in teaching Clojure to everyone who joins the company.